### PR TITLE
Fix `define-resource-directory` to actually work

### DIFF
--- a/hooks.lisp
+++ b/hooks.lisp
@@ -59,6 +59,5 @@
                  (status 1 "Error during ~a: ~a" type err))))))
 
 (defmacro define-resource-directory (name directory &key (copy-root T))
-  (let ((target (gensym "TARGET")))
-    `(define-hook (:deploy ,name) (,target)
-       (copy-directory-tree ,directory ,target :copy-root ,copy-root))))
+  `(define-hook (:deploy ,name) (directory)
+     (copy-directory-tree ,directory directory :copy-root ,copy-root)))


### PR DESCRIPTION
The macro was using a `gensym` for the target resource path, but
something in the hook system does some mangling of the arguments into
keyword arguments with magic names, so to actually get the target into
the hook properly it has to be named with the particular symbol
`directory`.

see https://github.com/Shinmera/deploy/issues/1