### PR TITLE
Fix compatibility with ClozureCL.

### DIFF
--- a/library.lisp
+++ b/library.lisp
@@ -58,7 +58,10 @@
   ;; FIXME: Maybe use ld.so.cache
   (remove NIL
           (append (library-sources library)
-                  (list (cffi::foreign-library-pathname library))
+                  (list
+                   (#+ccl ccl::shlib.pathname
+                    #-ccl identity
+                    (cffi::foreign-library-handle library)))
                   (when (library-system library)
                     (discover-subdirectories
                      (asdf:system-source-directory

--- a/library.lisp
+++ b/library.lisp
@@ -58,7 +58,7 @@
   ;; FIXME: Maybe use ld.so.cache
   (remove NIL
           (append (library-sources library)
-                  (list (cffi::foreign-library-handle library))
+                  (list (cffi::foreign-library-pathname library))
                   (when (library-system library)
                     (discover-subdirectories
                      (asdf:system-source-directory


### PR DESCRIPTION
Hello.
I've tried using deploy with ClozureCL and got the following error:
```
Error: The value #<SHLIB liballegro_audio.so.5.2 #x3020024F40CD> is not of the expected type (OR PATHNAME STREAM STRING).
```
with the following backtrace (truncated for clarity):
```
 (7FF883E25A20) : 0 (PATHNAME #<SHLIB liballegro_audio.so.5.2 #x3020024F403D>) 341
 (7FF883E25A38) : 1 (MERGE-PATHNAMES #P"liballegro_audio.so.5.2" #<SHLIB liballegro_audio.so.5.2 #x3020024F403D> :NEWEST) 285
 (7FF883E25A90) : 2 (FUNCALL #'#<#<STANDARD-METHOD DEPLOY:FIND-SOURCE-FILE (DEPLOY:LIBRARY)>> #<LIBRARY LIBALLEGRO-AUDIO>) 229
```
Upon investingating I found out that `cffi:foreign-library-handle` returns the PATHNAME object in SBCL, but under CCL it returns SHLIB object. I've tried replacing the call to `cffi:foreign-library-handle` with `cffi:foreign-library-pathname`, and it seemingly does the right thing - I was able to build my project using both SBCL and CCL.