### PR TITLE
Add more library paths for arm and arm64

### DIFF
--- a/library.lisp
+++ b/library.lisp
@@ -19,6 +19,9 @@
         #+(and unix x86-64) #p"/usr/lib64/"
         #+(and unix x86-64) #p"/usr/lib/x86_64-linux-gnu/"
         #+(and unix x86) #p"/usr/lib/x86-linux-gnu/"
+        #+(and unix arm64) #p"/usr/lib/aarch64-linux-gnu/"
+        #+(and unix arm) #p"/usr/lib/arm-linux-gnueabi/"
+        #+(and unix arm) #p"/usr/lib/arm-linux-gnueabihf/"
         #+unix #p"/usr/lib/*/"
         #+darwin #p"/opt/local/lib"
         #+darwin #p"/usr/local/Cellar/**/lib/"))


### PR DESCRIPTION
These paths seem to cover both Ubuntu and Debian.