### PR TITLE
Determine :DEPLOY-CONSOLE feature at run time, not READ time

### DIFF
--- a/deploy.lisp
+++ b/deploy.lisp
@@ -146,17 +146,19 @@
                           :purify T
                           :toplevel-function #'uiop:restore-image
                           :application-type
-                          #+deploy-console :console
-                          #-deploy-console :gui)
+                          (if (uiop:featurep :deploy-console)
+                              :console
+                              :gui))
     #-(and windows ccl)
     (apply #'uiop:dump-image file
            (append '(:executable T)
                    #+sb-core-compression
                    '(:compression T)
                    #+(and sbcl os-windows)
-                   '(:application-type
-                     #+deploy-console :console
-                     #-deploy-console :gui)))))
+                   `(:application-type
+                     ,(if (uiop:featurep :deploy-console)
+                          :console
+                          :gui))))))
 
 ;; hook ASDF
 (flet ((export! (symbol package)


### PR DESCRIPTION
Previously, the :DEPLOY-CONSOLE feature had to be present before the system was
loaded in order for it to have any effect. In addition to forcing systems that
depend on deploy to set this flag as early as possible, it also means that if
:DEPLOY-CONSOLE is toggled after deploy is already in ASDF's .fasl cache its
effects won't be seen unless it is force loaded or removed the cache and
recompiled.

Now, its presence is checked at run time, working around the above issues.