### PR TITLE
Make define-library work on ccl when the library is not loaded yet.

### DIFF
--- a/library.lisp
+++ b/library.lisp
@@ -61,10 +61,10 @@
   ;; FIXME: Maybe use ld.so.cache
   (remove NIL
           (append (library-sources library)
-                  (list
-                   (#+ccl ccl::shlib.pathname
-                    #-ccl identity
-                    (cffi::foreign-library-handle library)))
+                  #-ccl (list (cffi::foreign-library-handle library))
+                  #+ccl (let ((handle (cffi::foreign-library-handle library)))
+                          (when handle
+                            (list (ccl::shlib.pathname handle))))
                   (cffi::foreign-library-search-path library)
                   (when (library-system library)
                     (discover-subdirectories


### PR DESCRIPTION
Fix deploy on CCL (somewhat discussed on #shirakumo)