### PR TITLE
Try to print library name symbols with their packages

### DIFF
--- a/library.lisp
+++ b/library.lisp
@@ -39,7 +39,7 @@
 
 (defmethod print-object ((library library) stream)
   (print-unreadable-object (library stream :type T)
-    (format stream "~a" (library-name library))))
+    (format stream "~s" (library-name library))))
 
 (defmethod library-dont-deploy-p ((library library))
   (if (slot-boundp library 'dont-deploy)


### PR DESCRIPTION
Hey! This tiny pull request adds CFFI library's package to its printed representation, so one can finally get where that freaky stray GDI32 comes from 😅 

![2025-05-24-110442_922x201_scrot](https://github.com/user-attachments/assets/d121c513-0fc7-4616-9a4f-abebce660917)
